### PR TITLE
"help [command]]" in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ with custom directory shortcuts so called warp points.
 Warping to a path pushes the path on the directory stack.
 Navigation back can be achieved with either "popd" or "wd ..".
 
+## Requirements
+
+Fish version 2.3 is required for the new string function.
+
 ## Install
 
 With [Oh My Fish][omf-link]:

--- a/functions/wd.fish
+++ b/functions/wd.fish
@@ -62,7 +62,7 @@ function __wd_help --argument command
             echo "-q | --quiet    Suppress all output"
             echo "-f | --force    Equivalent to '!' with add and clean"
             echo
-            echo "help [command]] Shows help abput specific command"
+            echo "help [command]  Shows help abput specific command"
 
         case ".."
             echo "Pops the last directory from the directory stack"

--- a/functions/wd.fish
+++ b/functions/wd.fish
@@ -62,7 +62,7 @@ function __wd_help --argument command
             echo "-q | --quiet    Suppress all output"
             echo "-f | --force    Equivalent to '!' with add and clean"
             echo
-            echo "help [command]  Shows help abput specific command"
+            echo "help [command]  Shows help about specific command"
 
         case ".."
             echo "Pops the last directory from the directory stack"


### PR DESCRIPTION
I saw that the help screen has "help [command]]" with two brackets.
So I removed one :)
