### PR TITLE
Added fish 2.3 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ with custom directory shortcuts so called warp points.
 Warping to a path pushes the path on the directory stack.
 Navigation back can be achieved with either "popd" or "wd ..".
 
+## Requirements
+
+Fish version 2.3 is required for the new string function.
+
 ## Install
 
 With [Oh My Fish][omf-link]:


### PR DESCRIPTION
As port author mentioned in a thread:

"...my wd port use the string function build into fish. Which is introduced in fish 2.3.
I should have mentioned this in the readme."

So I added the mention, and I hope it's okay.
