### PR TITLE
Typo in help text

### DIFF
--- a/functions/wd.fish
+++ b/functions/wd.fish
@@ -62,7 +62,7 @@ function __wd_help --argument command
             echo "-q | --quiet    Suppress all output"
             echo "-f | --force    Equivalent to '!' with add and clean"
             echo
-            echo "help [command]] Shows help abput specific command"
+            echo "help [command]  Shows help about specific command"
 
         case ".."
             echo "Pops the last directory from the directory stack"


### PR DESCRIPTION
Help text for the help command itself contains double closing bracket and a typo in the word "about" ("abput").
Fixing those.
